### PR TITLE
Update cssnext, fixes #3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 node_js:
-- "0.12"
+- "stable"
 - "4"
 sudo: false
 language: node_js

--- a/index.js
+++ b/index.js
@@ -25,7 +25,18 @@ function transform (filename, source, options, done) {
   }, options || {})
 
   processor.process(source, poptions).then(function (result) {
-    done(null, result.css)
+    // Collect imported files for watchify
+    const files = [filename]
+    result.messages.forEach(function (msg) {
+      if (msg.type === 'dependency') {
+        files.push(msg.file)
+      }
+    })
+
+    done(null, {
+      css: result.css,
+      files: files
+    })
   }, function (err) {
     done(err)
   })

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "dependency-check": "^2.5.1",
     "istanbul": "^0.4.1",
-    "standard": "^5.4.1",
+    "standard": "^10.0.3",
     "tape": "^4.2.1"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -32,5 +32,8 @@
     "istanbul": "^0.4.1",
     "standard": "^5.4.1",
     "tape": "^4.2.1"
+  },
+  "engines": {
+    "node": ">= 4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "cssnext": "^1.8.4",
+    "postcss": "^6.0.17",
+    "postcss-cssnext": "^3.1.0",
+    "postcss-import": "^11.0.0",
     "xtend": "^4.0.0"
   },
   "devDependencies": {

--- a/test.js
+++ b/test.js
@@ -3,25 +3,37 @@ const test = require('tape')
 const path = require('path')
 const fs = require('fs')
 
-test('basic', compare('basic.css', 'basic-out.css'))
-test('import', compare('import.css', 'basic-out.css'))
+test('basic', function (t) {
+  t.plan(1)
 
-function compare (inputFile, outputFile) {
-  return function compareTest (t) {
-    const file = path.join(__dirname, 'fixtures', inputFile)
-    const src = fs.readFileSync(file, 'utf8')
-    const expected = fs.readFileSync(
-      path.join(__dirname, 'fixtures', outputFile)
-    , 'utf8')
+  const file = path.join(__dirname, 'fixtures/basic.css')
+  const src = fs.readFileSync(file, 'utf8')
+  const expected = fs.readFileSync(path.join(__dirname, 'fixtures/basic-out.css'), 'utf8')
 
-    t.plan(1)
+  transform(file, src, {
+    sourcemap: false
+  }, function (err, actual) {
+    if (err) return t.error(err)
 
-    transform(file, src, {
-      sourcemap: false
-    }, function (err, actual) {
-      if (err) return t.error(err)
+    t.equal(actual.css, expected, 'output is as expected')
+  })
+})
+test('import', function (t) {
+  t.plan(2)
 
-      t.equal(actual, expected, 'output is as expected')
-    })
-  }
-}
+  const file = path.join(__dirname, 'fixtures/import.css')
+  const src = fs.readFileSync(file, 'utf8')
+  const expected = fs.readFileSync(path.join(__dirname, 'fixtures/basic-out.css'), 'utf8')
+
+  transform(file, src, {
+    sourcemap: false
+  }, function (err, actual) {
+    if (err) return t.error(err)
+
+    t.equal(actual.css, expected, 'output is as expected')
+    t.deepEqual(actual.files, [
+      file,
+      path.join(__dirname, 'fixtures/basic.css')
+    ], 'lists imported files')
+  })
+})


### PR DESCRIPTION
Breaking change. The `cssnext` package is deprecated. This patch requires Node 4+