### PR TITLE
Restore Node 4 support

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,12 @@ const cssnext = require('postcss-cssnext')
 const imports = require('postcss-import')
 const xtend = require('xtend')
 
+// Patch CSSNext features map to ensure Node v4 support
+const features = require('postcss-cssnext/lib/features').default
+features.calc = function calc (options) {
+  return require('postcss-calc')(options)
+}
+
 module.exports = transform
 
 function transform (filename, source, options, done) {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "license": "MIT",
   "dependencies": {
     "postcss": "^6.0.17",
+    "postcss-calc": "6.0.1",
     "postcss-cssnext": "^3.1.0",
     "postcss-import": "^11.0.0",
     "xtend": "^4.0.0"


### PR DESCRIPTION
postcss-calc dropped support for Node 4 in a patch release, this should make us use the old version instead.